### PR TITLE
Add fstrim systemd timer to collect freed space

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,12 @@
     name: "{{ vdo_pkgs_list }}"
     state: installed
 
+- name: Enable a timer unit for fstrim
+  ansible.builtin.systemd_service:
+    name: fstrim.timer
+    state: started
+    enabled: true
+
 
 # "lvcreate --type vdo" creates two LVs. Thus, we need to check and see if it already exists,
 # if no, create a single LV with the right options

--- a/vars/CentOS-9.yml
+++ b/vars/CentOS-9.yml
@@ -4,3 +4,4 @@ vdo_pkgs_list:
   - lvm2
   - kmod-kvdo
   - vdo
+  - util-linux

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -4,3 +4,4 @@ vdo_pkgs_list:
   - lvm2
   - kmod-kvdo
   - vdo
+  - util-linux


### PR DESCRIPTION
Adds the fstrim timer as per [the Red Hat docs](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/deduplicating_and_compressing_logical_volumes_on_rhel/trim-options-on-an-lvm-vdo-volume_deduplicating-and-compressing-logical-volumes-on-rhel#setting-up-periodic-trim-operation_trim-options-on-an-lvm-vdo-volume)